### PR TITLE
closes #47 add support for gzip compression for all http responses

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -83,6 +83,7 @@ func printConfigSummary() {
 		"server.bind_port",
 		"server.tls.enabled",
 		"server.access_log",
+		"server.compression",
 		"aws.polling_interval",
 		"aws.required_tag_key",
 		"aws.required_tag_value",

--- a/testdata/sampleconfig/power-toggle-config.yaml
+++ b/testdata/sampleconfig/power-toggle-config.yaml
@@ -13,6 +13,10 @@ server:
   # enable access log on stdout
   access_log: false
 
+  # enable supported compression of http responses when client requests for it
+  # currently only gzip is supported
+  compression: true
+
   # TLS options
   tls:
     # enables TLS


### PR DESCRIPTION
this is is optional, can be enabled for trading slightly higher cpu usage for much smaller response sizes. Sample config keeps it enabled by default